### PR TITLE
Update pad.py

### DIFF
--- a/src/pytimetk/core/pad.py
+++ b/src/pytimetk/core/pad.py
@@ -144,6 +144,9 @@ def pad_by_time(
         
         padded_df.sort_values(by=[date_column], inplace=True)
         padded_df.reset_index(drop=True, inplace=True)
+
+        col_name = padded_df.columns[padded_df.nunique() == 1][0]
+        padded_df = padded_df.assign(**{f'{col_name}': padded_df[col_name].ffill()})
         
         return padded_df
     


### PR DESCRIPTION
There was a notable inconsistency in how a singular dataframe without groups worked versus with groups in that the forward filling of names worked for group without the need for an assign, but not for the singular dataframe. 

To resolve this I used a simple trick to find the column that have only a single value extract that name and then forward filled. This removes the need for any additional code as in the example currently in the docs.