### PR TITLE
Update pad.py

### DIFF
--- a/src/pytimetk/core/pad.py
+++ b/src/pytimetk/core/pad.py
@@ -144,6 +144,14 @@ def pad_by_time(
         
         padded_df.sort_values(by=[date_column], inplace=True)
         padded_df.reset_index(drop=True, inplace=True)
+
+        col_name = padded_df.columns[padded_df.nunique() == 1]
+        if not col_name.empty:
+            col_name = col_name[0]
+        else:
+            col_name = None
+
+        padded_df = padded_df.assign(**{f'{col_name}': padded_df[col_name].ffill()})
         
         return padded_df
     


### PR DESCRIPTION
The current pandas implementation behaves differently for singular dataframes without groups versus groups in that the latter forward fills names and the former requires further data wrangling.