### PR TITLE
Update lags.py fixed docstring

### DIFF
--- a/src/pytimetk/feature_engineering/lags.py
+++ b/src/pytimetk/feature_engineering/lags.py
@@ -84,6 +84,7 @@ def augment_lags(
             )
     )
     lagged_df_single
+    ```
 
     # Example 2 - Add a single lagged value of 2 for each GroupBy object, polars engine
     lagged_df = (


### PR DESCRIPTION
Docstring was not producing all 3 examples because it was missing ``` this should fix the API/reference for lags